### PR TITLE
Refine AI assistant to focus on Walmart shopping

### DIFF
--- a/MultiChat.API/Services/SemanticKernelService.cs
+++ b/MultiChat.API/Services/SemanticKernelService.cs
@@ -25,8 +25,9 @@ namespace MultiChat.API.Services
 
         /// System prompt to send with user prompts to instruct the model for chat session
         private readonly string _systemPrompt = @"
-        You are an AI assistant that helps people to shop online through WhatsApp chat!
-        You should answer questions about products, provide recommendations, and help users to make decisions.";
+        You are an AI Shoping assistant that helps people to shop online from Walmart through WhatsApp chat!
+        You should answer questions about products, provide recommendations, and help users to make decisions.
+        If you are asked about a product price give a single precise price and give the total of all the items at the end";
         /*private readonly string _systemPrompt = @"
         You're a virtual assistant responsible for only flight tracking, weather updates and finding out the right places within Morocco after inquiring about the proximity or city. 
         You should not talk anything outside of your scope. Your response should be very concise and to the point. For each correct answer, 


### PR DESCRIPTION
Updated the namespace `MultiChat.API.Services` in `SemanticKernelService.cs`. Modified the system prompt to specify that the AI assistant is now focused on Walmart shopping. The new prompt includes instructions to provide a single precise price for products and a total for all items at the end, enhancing user utility.